### PR TITLE
Removed googlemaps isSecure because it is not necessary

### DIFF
--- a/services/GoogleMaps_TemplatesService.php
+++ b/services/GoogleMaps_TemplatesService.php
@@ -5,18 +5,10 @@ class GoogleMaps_TemplatesService extends BaseApplicationComponent
 {
     public function scripts()
     {
-        if($this->isSecure())
-        {
-            $protocol = 'https://';
-        }
-        else 
-        {
-            $protocol = 'http://';
-        }
 
         $key = craft()->config->get('key', 'googlemaps');
 
-        craft()->templates->includeJsFile($protocol . 'maps.google.com/maps/api/js?sensor=true&libraries=geometry'.($key ? 'key='.$key : ''));
+        craft()->templates->includeJsFile('//maps.google.com/maps/api/js?sensor=true&libraries=geometry'.($key ? 'key='.$key : ''));
         craft()->templates->includeJsResource('googlemaps/js/vendor/base.js');
         craft()->templates->includeJsResource('googlemaps/js/vendor/underscore.js');
         craft()->templates->includeJsResource('googlemaps/js/vendor/markerclusterer.js');
@@ -186,9 +178,4 @@ class GoogleMaps_TemplatesService extends BaseApplicationComponent
         }, json_encode($data));
     }
 
-    public function isSecure()
-    {
-      	return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443 || $_SERVER['HTTP_X_FORWARDED_PORT'] == 443;
-    }
-    
 }

--- a/services/GoogleMaps_TemplatesService.php
+++ b/services/GoogleMaps_TemplatesService.php
@@ -188,9 +188,7 @@ class GoogleMaps_TemplatesService extends BaseApplicationComponent
 
     public function isSecure()
     {
-      return
-        (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
-        || $_SERVER['SERVER_PORT'] == 443;
+      	return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443 || $_SERVER['HTTP_X_FORWARDED_PORT'] == 443;
     }
     
 }


### PR DESCRIPTION
In some use-cases there is only a forwarded port with 443 and not the server port. (cloudfront)
