### PR TITLE
Allow override of default zoom

### DIFF
--- a/resources/js/plugin.js
+++ b/resources/js/plugin.js
@@ -68,11 +68,8 @@ var GoogleMaps = {
 			}
 
 			var defaultMapOptions = {
-				center: new google.maps.LatLng(
-					(options.lat ? options.lat : 0), 
-					(options.lng ? options.lng : 0)
-				),
-				zoom: (options.zoom ? options.zoom : 10)
+				center: new google.maps.LatLng(0,0),
+				zoom: 10
 			};
 
 			this.el = node;
@@ -91,7 +88,7 @@ var GoogleMaps = {
 			
 			this.base(options);
 
-			this.options = _.extend({}, defaultMapOptions, this.options);
+			this.options = _.extend({}, defaultMapOptions, options);
 
 			this.api = new google.maps.Map(node, this.options);
 

--- a/resources/js/plugin.js
+++ b/resources/js/plugin.js
@@ -72,7 +72,7 @@ var GoogleMaps = {
 					(options.lat ? options.lat : 0), 
 					(options.lng ? options.lng : 0)
 				),
-				zoom: 10
+				zoom: (options.zoom ? options.zoom : 10)
 			};
 
 			this.el = node;


### PR DESCRIPTION
In the situation of having 1 (or more markers) and fitBounds = false. Being option to override the default zoom level of 10.
*If Google Maps isn't using fitBounds, map requires center-point and zoom: ttps://developers.google.com/maps/documentation/javascript/tutorial#MapOptions
