### PR TITLE
Mixed Content being loaded over https

### DIFF
--- a/resources/js/templates.js
+++ b/resources/js/templates.js
@@ -920,7 +920,7 @@ function program5(depth0,data,depth1) {
 function program7(depth0,data) {
   
   
-  return "http://mt.googleapis.com/vt/icon/name=icons/spotlight/spotlight-poi.png&scale=2";
+  return "https://mt.googleapis.com/vt/icon/name=icons/spotlight/spotlight-poi.png&scale=2";
   }
 
 function program9(depth0,data) {


### PR DESCRIPTION
The marker icon was being loaded over http which breaks on https environments. Loading as https does not have any ill effects for http environments.
